### PR TITLE
cd:workflows: Add o deploy do código no s3

### DIFF
--- a/.github/workflows/deploy_code_base.yml
+++ b/.github/workflows/deploy_code_base.yml
@@ -1,0 +1,23 @@
+# This is a basic workflow to help you get started with Actions
+
+name: deploy
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkint out the code
+        uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Deploy
+        run: aws s3 sync ./ s3://dados-de-manchetes-code-base/baixar_html/


### PR DESCRIPTION
Para possibilitar o acesso dos código na aws é feito o deploy no s3(dados-de-manchetes-code-base) na pasta baixar_html.