### PR TITLE
infr:tf:instance: Modificando o tipo da instanceia para baratear custos

### DIFF
--- a/infr/tf/instance.tf
+++ b/infr/tf/instance.tf
@@ -2,7 +2,7 @@
 resource "aws_instance" "baixar_html" {
 
   ami           = "ami-0f9fc25dd2506cf6d" # Amazon linux 2
-  instance_type = "m6a.large"
+  instance_type = "t3a.small"
   iam_instance_profile = "${aws_iam_instance_profile.baixar_html.id}"
 
   vpc_security_group_ids = [aws_security_group.baixar_html.id]


### PR DESCRIPTION
Mudando de uma m6a.large para uma t3a.small. A modificação é para
baratear os custos de execução.