### PR TITLE
gitignore: Removendo arquivos do vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ infr/tf/.terraform.lock.hcl
 infr/tf/terraform.tfstate.backup
 infr/tf/.terraform/providers/
 infr/tf/terraform.tfstate
+.vscode


### PR DESCRIPTION
Por utilizar o vscode no desenvolvimento, é removido do projeto qualquer
arquivo criado para configuração dele.